### PR TITLE
Removed the history navigation from navbar. 

### DIFF
--- a/components/shared/navbar.tsx
+++ b/components/shared/navbar.tsx
@@ -1,11 +1,6 @@
 import React from "react";
 import Link from "next/link";
-import {
-  DashboardIcon,
-  PlusIcon,
-  PersonIcon,
-  CounterClockwiseClockIcon,
-} from "@radix-ui/react-icons";
+import { DashboardIcon, PlusIcon, PersonIcon } from "@radix-ui/react-icons";
 import {
   Tooltip,
   TooltipContent,
@@ -25,11 +20,6 @@ const Navigations = [
     name: "Add request",
     href: "/add-request",
     icon: PlusIcon,
-  },
-  {
-    name: "History",
-    href: "/history",
-    icon: CounterClockwiseClockIcon,
   },
   {
     name: "Profile",


### PR DESCRIPTION
The user donation and request history are moved to their user profile. Eliminating the need of extra `/history` navigation page. 